### PR TITLE
Read total_amount as sum of all total_prices

### DIFF
--- a/lib/mpower/checkout/redirect_invoice.rb
+++ b/lib/mpower/checkout/redirect_invoice.rb
@@ -2,8 +2,8 @@ module MPower
   module Checkout
     class Invoice < MPower::Checkout::Core
 
-      attr_accessor :items, :total_amount, :taxes, :description, :currency, :store
-      attr_accessor :customer, :custom_data, :cancel_url, :return_url, :invoice_url, :receipt_url
+      attr_reader :items, :taxes, :description, :currency, :store
+      attr_reader :customer, :custom_data, :cancel_url, :return_url, :invoice_url, :receipt_url
 
       def initialize
         @items = {}
@@ -15,6 +15,7 @@ module MPower
         @store = MPower::Checkout::Store
         @return_url = @store.return_url
         @cancel_url = @store.cancel_url
+        yield(self) if block_given?
       end
 
       # Adds invoice items to the @items hash, the idea is to allow this function to be used in a loop
@@ -28,7 +29,22 @@ module MPower
             :description => description
           }
         })
+
+        self
       end
+
+
+      # Total amount should be the sum of the total_prices of all items in the invoice.
+      def total_amount
+        @items.map { |u, v| v[:total_price] }.reduce(:+)
+      end
+
+
+      # Total number of items
+      def size
+        @items.size
+      end
+
 
       # Adds invoice tax to the @taxes hash, the idea is to allow this function to be used in a loop
       def add_tax(name,amount)

--- a/test/test_mpower.rb
+++ b/test/test_mpower.rb
@@ -1,16 +1,40 @@
-require 'test/unit'
+require 'minitest/spec'
+require 'minitest/autorun'
 require 'mpower'
 
-class TestMPower < Test::Unit::TestCase
-  def test_checkout_invoice_items
-    invoice = MPower::Checkout::Invoice.new
-    invoice.add_item("Cart Item 1",1,10.00,10.00,"with optional description")
-    invoice.add_item("Cart Item 2",5,5.00,25.00)
-    invoice.total_amount = 55.00
-    invoice.description = "Unit::Test Invoice from Ruby lang"
-    assert_instance_of(Hash, invoice.get_items)
-    assert_equal(2, invoice.get_items.size)
-    assert_instance_of(Hash, invoice.get_items[:item_0])
-    assert_equal(5, invoice.get_items[:item_0].size)
+describe MPower::Checkout::Invoice do
+  before do
+    @invoice = MPower::Checkout::Invoice.new do |inv|
+      inv.
+        add_item("Cart Item 1",1,10.00,10.00,"with optional description").
+        add_item("Cart Item 2",5,5.00,25.00)
+    end
+  end
+
+  describe "#items" do
+    it "should have 3 items in the invoice" do
+      @invoice.add_item("Cart Item 3", 3, 3.33, 9.99, "Cart Item 3 has description. Yay!")
+      @invoice.items.size.must_equal 3
+    end
+
+    it "should be a Hash" do
+      @invoice.items.must_be_instance_of Hash
+      @invoice.items.each { |u, v| v.must_be_instance_of Hash }
+    end
+  end
+
+  describe "#total_amount" do
+    it "should have total_amount equal to sum of all total_prices" do
+      @invoice.total_amount.must_equal 35.00
+
+      @invoice.add_item("Cart Item 3", 3, 3.33, 9.99, "Cart Item 3 has description. Yay!")
+      @invoice.add_item("Cart Item 4", 4, 4.44, 17.76)
+
+      @invoice.total_amount.must_equal 62.75
+    end
+
+    it "should not allow total_amount to be manually set" do
+      lambda { @invoice.total_amount = 1.00 }.must_raise NoMethodError
+    end
   end
 end


### PR DESCRIPTION
Added `total_amount` as a method on `MPower::Checkout::Invoice`. It sums the
total_prices of all items in the invoice. The value is calculated
everytime `invoice.total_amount` is called. Ideally it shouldn't be
called the MPower client.

In my opinion this address 2 potential problems:
- Application developers forgetting to set `total_amount`. (happened
  to me)
- Application developers setting `total_amount` to a value not
  consistent with total price of all items bought. In their haste,
  customers may not confirm that they are paying the right price
  before submitting their confirmation token. This helps prevent
  potential fraud.

Tests included.
